### PR TITLE
Added ability to use the bundle with default config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@
 
 # Composer PHAR
 /composer.phar
+/composer.lock

--- a/.gitignore
+++ b/.gitignore
@@ -1,38 +1,4 @@
-# Cache and logs (Symfony2)
-/app/cache/*
-/app/logs/*
-!app/cache/.gitkeep
-!app/logs/.gitkeep
-
-# Cache and logs (Symfony3)
-/var/cache/*
-/var/logs/*
-!var/cache/.gitkeep
-!var/logs/.gitkeep
-
-# Parameters
-/app/config/parameters.yml
-/app/config/parameters.ini
-
-# Managed by Composer
-/app/bootstrap.php.cache
-/var/bootstrap.php.cache
-/bin/*
-!bin/console
-!bin/symfony_requirements
 /vendor/
-
-# Assets and user uploads
-/web/bundles/
-/web/uploads/
-
-# PHPUnit
-/app/phpunit.xml
-/phpunit.xml
-
-# Build data
-/build/
-
-# Composer PHAR
 /composer.phar
 /composer.lock
+/phpunit.xml

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -22,7 +22,6 @@ class Configuration implements ConfigurationInterface
 
         $rootNode->children()
             ->scalarNode('revision_manifest')
-                ->isRequired()
                 ->cannotBeEmpty()
                 ->defaultValue('%kernel.root_dir%/../webpack-assets.json')
             ->end()

--- a/Tests/DependencyInjection/Ju1iusWebpackAssetsExtensionTest.php
+++ b/Tests/DependencyInjection/Ju1iusWebpackAssetsExtensionTest.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace ju1ius\WebpackAssetsBundle\Tests\DependencyInjection;
+
+use ju1ius\WebpackAssetsBundle\DependencyInjection\Ju1iusWebpackAssetsExtension;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+class Ju1iusWebpackAssetsExtensionTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var ContainerBuilder;
+     */
+    private $container;
+
+    /**
+     * @var Ju1iusWebpackAssetsExtension;
+     */
+    private $extension;
+
+    public function testLoadWithDefaults()
+    {
+        $this->extension->load(array(), $this->container);
+
+        $this->assertTrue($this->container->hasDefinition('ju1ius_webpack_assets.asset_helper'));
+        $this->assertEquals(
+            array(
+                '%kernel.root_dir%/../webpack-assets.json'
+            ),
+            $this->container->getDefinition('ju1ius_webpack_assets.asset_helper')->getArguments()
+        );
+    }
+
+    public function testLoadWithCustomConfig()
+    {
+        $this->extension->load(
+            array(
+                'ju1ius_webpack_assets' => array(
+                    'revision_manifest' => 'rev-manifest.json'
+                )
+            ),
+            $this->container
+        );
+
+        $this->assertEquals(
+            array(
+                'rev-manifest.json'
+            ),
+            $this->container->getDefinition('ju1ius_webpack_assets.asset_helper')->getArguments()
+        );
+    }
+
+    protected function setUp()
+    {
+        $this->container = new ContainerBuilder();
+        $this->extension = new Ju1iusWebpackAssetsExtension();
+    }
+
+    protected function tearDown()
+    {
+        unset($this->container, $this->extension);
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -14,8 +14,12 @@
     ],
     "require": {
         "php": ">=5.4.0",
+        "symfony/config": "^2.7|^3.0",
         "symfony/dependency-injection": "^2.7|^3.0",
         "symfony/twig-bundle": "^2.7|^3.0"
+    },
+    "require-dev": {
+        "phpunit/phpunit": "^5.0"
     },
     "autoload": {
         "psr-4": { "ju1ius\\WebpackAssetsBundle\\": "" }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<phpunit bootstrap="vendor/autoload.php" colors="true">
+    <testsuites>
+        <testsuite name="Ju1iusWebpackAssetsBundle">
+            <directory>./Tests</directory>
+        </testsuite>
+    </testsuites>
+
+    <filter>
+        <whitelist>
+            <directory>.</directory>
+            <exclude>
+                <directory>./Resources</directory>
+                <directory>./Tests</directory>
+                <directory>./vendor</directory>
+            </exclude>
+        </whitelist>
+    </filter>
+</phpunit>


### PR DESCRIPTION
Before, we need to add `ju1ius_webpack_assets: ~` to app config. When we want use this bundle with default config.
This PR allows use the bundle without modify app config, in some cases.
