### PR TITLE
Fixed typo

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -18,7 +18,7 @@ class Configuration implements ConfigurationInterface
     public function getConfigTreeBuilder()
     {
         $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('ju1ius_webpack');
+        $rootNode = $treeBuilder->root('ju1ius_webpack_assets');
 
         $rootNode->children()
             ->scalarNode('revision_manifest')


### PR DESCRIPTION
To prevent confusing errors:

```
The child node "revision_manifest" at path "ju1ius_webpack" must be configured.
```
